### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,8 +1,5 @@
 // Editor styles (background, gutter, guides)
-// <- remove when Shadow DOM can't be disabled
-
-atom-text-editor,
-:host {
+atom-text-editor {
     background-color: @syntax-background-color;
     color           : @syntax-text-color;
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,315 +1,315 @@
 // Language syntax highlighting
 
 
-.comment {
+.syntax--comment {
     color     : @mono-3;
     font-style: italic;
 
 
-    .markup.link {
+    .syntax--markup.syntax--link {
         color: @mono-3;
     }
 }
 
 
 
-.entity {
-    &.name.type {
+.syntax--entity {
+    &.syntax--name.syntax--type {
         color: @hue-6-2;
     }
 
 
-    &.other.inherited-class {
+    &.syntax--other.syntax--inherited-class {
         color: @hue-4;
     }
 }
 
 
-.keyword {
+.syntax--keyword {
     color: @hue-3;
 
 
-    &.control {
+    &.syntax--control {
         color: @hue-3;
     }
 
 
-    &.operator {
+    &.syntax--operator {
         color: @mono-1;
     }
 
 
-    &.other.special-method {
+    &.syntax--other.syntax--special-method {
         color: @hue-2;
     }
 
 
-    &.other.unit {
+    &.syntax--other.syntax--unit {
         color: @hue-6;
     }
 }
 
 
-.storage {
+.syntax--storage {
     color: @hue-3;
 
 
-    &.type {
-        &.annotation,
-        &.primitive {
+    &.syntax--type {
+        &.syntax--annotation,
+        &.syntax--primitive {
             color: @hue-3;
         }
     }
 
 
-    &.modifier {
-        &.package,
-        &.import {
+    &.syntax--modifier {
+        &.syntax--package,
+        &.syntax--import {
             color: @mono-1;
         }
     }
 }
 
 
-.constant {
+.syntax--constant {
     color: @hue-6;
 
 
-    &.variable {
+    &.syntax--variable {
         color: @hue-6;
     }
 
 
-    &.character.escape {
+    &.syntax--character.syntax--escape {
         color: @hue-1;
     }
 
 
-    &.numeric {
+    &.syntax--numeric {
         color: @hue-6;
     }
 
 
-    &.other.color {
+    &.syntax--other.syntax--color {
         color: @hue-1;
     }
 
 
-    &.other.symbol {
+    &.syntax--other.syntax--symbol {
         color: @hue-1;
     }
 }
 
 
-.variable {
+.syntax--variable {
     color: @hue-5;
 
 
-    &.interpolation {
+    &.syntax--interpolation {
         color: @hue-5-2;
     }
 
 
-    &.parameter {
+    &.syntax--parameter {
         color: @mono-1;
     }
 }
 
 
-.string {
+.syntax--string {
     color: @hue-4;
 
 
-    &.regexp {
+    &.syntax--regexp {
         color: @hue-1;
 
 
-        .source.ruby.embedded {
+        .syntax--source.syntax--ruby.syntax--embedded {
             color: @hue-6-2;
         }
     }
 
 
-    &.other.link {
+    &.syntax--other.syntax--link {
         color: @hue-5;
     }
 }
 
 
-.punctuation {
-    &.definition {
-        &.comment {
+.syntax--punctuation {
+    &.syntax--definition {
+        &.syntax--comment {
             color: @mono-3;
         }
 
 
-        &.method-parameters,
-        &.function-parameters,
-        &.parameters,
-        &.separator,
-        &.seperator,
-        &.array {
+        &.syntax--method-parameters,
+        &.syntax--function-parameters,
+        &.syntax--parameters,
+        &.syntax--separator,
+        &.syntax--seperator,
+        &.syntax--array {
             color: @mono-1;
         }
 
 
-        &.heading,
-        &.identity {
+        &.syntax--heading,
+        &.syntax--identity {
             color: @hue-2;
         }
 
 
-        &.bold {
+        &.syntax--bold {
             color      : @hue-6-2;
             font-weight: bold;
         }
 
 
-        &.italic {
+        &.syntax--italic {
             color     : @hue-3;
             font-style: italic;
         }
     }
 
 
-    &.section {
-        &.embedded {
+    &.syntax--section {
+        &.syntax--embedded {
             color: @hue-5-2;
         }
 
 
-        &.method,
-        &.class,
-        &.inner-class {
+        &.syntax--method,
+        &.syntax--class,
+        &.syntax--inner-class {
             color: @mono-1;
         }
     }
 }
 
 
-.support {
-    &.class {
+.syntax--support {
+    &.syntax--class {
         color: @hue-6-2;
     }
 
 
-    &.type {
+    &.syntax--type {
         color: @hue-1;
     }
 
 
-    &.function {
+    &.syntax--function {
         color: @hue-1;
 
 
-        &.any-method {
+        &.syntax--any-method {
             color: @hue-2;
         }
     }
 }
 
 
-.entity {
-    &.name.function {
+.syntax--entity {
+    &.syntax--name.syntax--function {
         color: @hue-2;
     }
 
 
-    &.name.class,
-    &.name.type.class {
+    &.syntax--name.syntax--class,
+    &.syntax--name.syntax--type.syntax--class {
         color: @hue-6-2;
     }
 
 
-    &.name.section {
+    &.syntax--name.syntax--section {
         color: @hue-2;
     }
 
 
-    &.name.tag {
+    &.syntax--name.syntax--tag {
         color: @hue-5;
     }
 
 
-    &.other.attribute-name {
+    &.syntax--other.syntax--attribute-name {
         color: @hue-6;
 
 
-        &.id {
+        &.syntax--id {
             color: @hue-2;
         }
     }
 }
 
 
-.meta {
-    &.class {
+.syntax--meta {
+    &.syntax--class {
         color: @hue-6-2;
 
 
-        &.body {
+        &.syntax--body {
             color: @mono-1;
         }
     }
 
 
-    &.method-call,
-    &.method {
+    &.syntax--method-call,
+    &.syntax--method {
         color: @mono-1;
     }
 
 
-    &.definition {
-        &.variable {
+    &.syntax--definition {
+        &.syntax--variable {
             color: @hue-5;
         }
     }
 
 
-    &.link {
+    &.syntax--link {
         color: @hue-6;
     }
 
 
-    &.require {
+    &.syntax--require {
         color: @hue-2;
     }
 
 
-    &.selector {
+    &.syntax--selector {
         color: @hue-3;
     }
 
 
-    &.separator {
+    &.syntax--separator {
         background-color: #373b41;
         color           : @mono-1;
     }
 
 
-    &.tag {
+    &.syntax--tag {
         color: @mono-1;
     }
 }
 
 
-.underline {
+.syntax--underline {
     text-decoration: underline;
 }
 
 
-.none {
+.syntax--none {
     color: @mono-1;
 }
 
 
-.invalid {
-    &.deprecated {
+.syntax--invalid {
+    &.syntax--deprecated {
         color           : @syntax-deprecated-fg !important;
         background-color: @syntax-deprecated-bg !important;
     }
 
-    &.illegal {
+    &.syntax--illegal {
         color           : @syntax-illegal-fg !important;
         background-color: @syntax-illegal-bg !important;
     }
@@ -317,55 +317,55 @@
 
 // Languages -------------------------------------------------
 
-.markup {
-    &.bold {
+.syntax--markup {
+    &.syntax--bold {
         color      : @hue-6;
         font-weight: bold;
     }
 
 
-    &.changed {
+    &.syntax--changed {
         color: @hue-3;
     }
 
 
-    &.deleted {
+    &.syntax--deleted {
         color: @hue-5;
     }
 
 
-    &.italic {
+    &.syntax--italic {
         color     : @hue-3;
         font-style: italic;
     }
 
 
-    &.heading {
+    &.syntax--heading {
         color: @hue-5;
 
 
-        .punctuation.definition.heading {
+        .syntax--punctuation.syntax--definition.syntax--heading {
             color: @hue-2;
         }
     }
 
 
-    &.link {
+    &.syntax--link {
         color: @hue-3;
     }
 
 
-    &.inserted {
+    &.syntax--inserted {
         color: @hue-4;
     }
 
 
-    &.quote {
+    &.syntax--quote {
         color: @hue-6;
     }
 
 
-    &.raw {
+    &.syntax--raw {
         color: @hue-4;
     }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,5 +1,5 @@
-.source.cs {
-    .keyword.operator {
+.syntax--source.syntax--cs {
+    .syntax--keyword.syntax--operator {
         color: @hue-3;
     }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,11 +1,11 @@
-.source.css {
+.syntax--source.syntax--css {
 
     // highlight properties/values if they are supported
-    .property-name,
-    .property-value {
+    .syntax--property-name,
+    .syntax--property-value {
         color: @mono-2;
 
-        &.support {
+        &.syntax--support {
             color: @mono-1;
         }
     }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,10 +1,10 @@
-.source.gfm {
-    .markup {
+.syntax--source.syntax--gfm {
+    .syntax--markup {
         -webkit-font-smoothing: auto;
     }
 
 
-    .link .entity {
+    .syntax--link.syntax--entity {
         color: @hue-2;
     }
 }

--- a/styles/languages/ini.less
+++ b/styles/languages/ini.less
@@ -1,5 +1,5 @@
-.source.ini {
-    .keyword.other.definition.ini {
+.syntax--source.syntax--ini {
+    .syntax--keyword.syntax--other.syntax--definition.syntax--ini {
         color: @hue-5;
     }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,23 +1,23 @@
-.source.java {
-    .storage {
-        &.modifier.import {
+.syntax--source.syntax--java {
+    .syntax--storage {
+        &.syntax--modifier.syntax--import {
             color: @hue-6-2;
         }
 
 
-        &.type {
+        &.syntax--type {
             color: @hue-6-2;
         }
     }
 }
 
 
-.source.java-properties {
-    .meta.key-pair {
+.syntax--source.syntax--java-properties {
+    .syntax--meta.syntax--key-pair {
         color: @hue-5;
 
 
-        & > .punctuation {
+        & > .syntax--punctuation {
             color: @mono-1;
         }
     }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,23 +1,23 @@
-.source.json {
-    .meta.structure.dictionary.json {
-        & > .string.quoted.json {
-            & > .punctuation.string {
+.syntax--source.syntax--json {
+    .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+        & > .syntax--string.syntax--quoted.syntax--json {
+            & > .syntax--punctuation.syntax--string {
                 color: @hue-5;
             }
-color: @hue-5;
+            color: @hue-5;
         }
     }
 
 
-    .meta.structure.dictionary.json,
-    .meta.structure.array.json {
-        & > .value.json > .string.quoted.json,
-        & > .value.json > .string.quoted.json > .punctuation {
+    .syntax--meta.syntax--structure.syntax--dictionary.syntax--json,
+    .syntax--meta.syntax--structure.syntax--array.syntax--json {
+        & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+        & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
             color: @hue-4;
         }
 
 
-        & > .constant.language.json {
+        & > .syntax--constant.syntax--language.syntax--json {
             color: @hue-1;
         }
     }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,10 +1,10 @@
-.source.python {
-    .keyword.operator.logical.python {
+.syntax--source.syntax--python {
+    .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
         color: @hue-3;
     }
 
 
-    .variable.parameter {
+    .syntax--variable.syntax--parameter {
         color: @hue-6;
     }
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,5 +1,5 @@
-.source.ruby {
-    .constant.other.symbol > .punctuation {
+.syntax--source.syntax--ruby {
+    .syntax--constant.syntax--other.syntax--symbol > .syntax--punctuation {
         color: inherit;
     }
 }


### PR DESCRIPTION
I got rid of all the deprecation warnings. Everything works still as expected on my side.

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--.
